### PR TITLE
option to write right to left

### DIFF
--- a/lib/hersheytext.js
+++ b/lib/hersheytext.js
@@ -116,6 +116,8 @@ exports.getFonts = () => [...Object.keys(exports.fonts), ...Object.keys(exports.
  *    charSpacingAdjust {int}: Amount to add or remove from between char spacing.
  *    charHeightAdjust {int}: Amount to add or remove from line height.
  *    scale {int}: Scale to multiply size of everything by
+ *    size {object}: {w, h} width and height of the canvas. Important only for rl writing
+ *    fromRight {bool}: write from the right side instead of the left if set
  *
  * @returns {string|boolean}
  *   Internal SVG content to be rendered as you see fit.
@@ -129,6 +131,8 @@ exports.renderTextSVG = function(text, rawOptions = {}) {
     charHeightAdjust: 0,
     scale: 2,
     pos: { x: 0, y: 0 },
+    size: {w: 0, h: 0 },
+    fromRight: false,
     ...rawOptions,
   };
 
@@ -139,7 +143,10 @@ exports.renderTextSVG = function(text, rawOptions = {}) {
     const font = getFontData(options.font);
     const multiplyer = font.type === 'svg' ? 1 : 1.68;
     const offset = { left: 0, top: 0 };
-
+    if( options.fromRight ) { 
+      // since scale affects everything, we need to make sure that the offset stays at the value we have set even when the scale is different
+      offset.left = (options.size.w * multiplyer) / options.scale;
+    } 
     // Create central group
     const $textGroup = $('g');
     $textGroup.attr({
@@ -165,6 +172,11 @@ exports.renderTextSVG = function(text, rawOptions = {}) {
         const rawChar = word[i];
         const char = font.getChar(rawChar);
 
+        // if we write from right, we need to position the character before we write, since the coordinate system is still counting from left
+        if (options.fromRight) {
+          offset.left -= (char.width * multiplyer) + options.charSpacingAdjust;
+        }
+
         // Only print in range chars
         if (char) {
           const $path = $('<path>').attr({
@@ -183,13 +195,19 @@ exports.renderTextSVG = function(text, rawOptions = {}) {
           // Add the char to the DOM group.
           $groupLine.append($path);
 
-          // Position next character.
-          offset.left += (char.width * multiplyer) + options.charSpacingAdjust;
+          if(!options.fromRight) { 
+            // Position next character.
+            offset.left += (char.width * multiplyer) + options.charSpacingAdjust;
+          }
         }
       }
 
       // Word boundary: Add a space.
-      offset.left+= parseInt(font.info['horiz-adv-x'], 10) + options.charSpacingAdjust;
+      if (options.fromRight) {
+        offset.left -= parseInt(font.info['horiz-adv-x'], 10) + options.charSpacingAdjust;
+      } else {
+        offset.left+= parseInt(font.info['horiz-adv-x'], 10) + options.charSpacingAdjust;
+      }
     }
 
   } catch(e) {


### PR DESCRIPTION
Hi,
I am working on generating svgs for arabic script. Since it is written from right to left I implemented that option as a toggle. Since the origin of the coordinate system stays the width can also be supplied since there is no way to know how wide the text is going to be before conversion. If you have an idea how to get around this I can add that as well.  

Best,
Kai